### PR TITLE
Fix java 11

### DIFF
--- a/src/main/java/net/imglib2/cache/CacheRemover.java
+++ b/src/main/java/net/imglib2/cache/CacheRemover.java
@@ -5,15 +5,23 @@ import java.util.function.Predicate;
 /**
  * Handles entries that are removed from a cache (by propagating to a
  * higher-level cache, writing to disk, or similar).
+ * <p>
+ * To make this work, it must be possible to {@link #extract(Object) extract}
+ * data {@code D} out of a value {@code V}, and to
+ * {@link #reconstruct(Object, Object) reconstruct} an identical value {@code V}
+ * from {@code D}. {@code D} must be sufficient to reconstruct an identical
+ * {@code V}, and must not contain any references to {@code V}.
  *
  * @param <K>
  *            key type
  * @param <V>
  *            value type
+ * @param <D>
+ *            value data type
  *
  * @author Tobias Pietzsch
  */
-public interface CacheRemover< K, V > extends Invalidate< K >
+public interface CacheRemover< K, V, D > extends Invalidate< K >
 {
 	/**
 	 * Called when an entry is evicted from the cache.
@@ -23,7 +31,19 @@ public interface CacheRemover< K, V > extends Invalidate< K >
 	 * @param valueData
 	 *            value data of the entry to remove
 	 */
-	void onRemoval( K key, V value );
+	void onRemoval( K key, D valueData );
+
+	/**
+	 * Extract data out of {@code value}. The data must be sufficient to
+	 * reconstruct an identical value, and must not contain any references to
+	 * value.
+	 */
+	D extract( V value );
+
+	/**
+	 * Construct a value from its {@code key} and {@code valueData}.
+	 */
+	V reconstruct( K key, D valueData );
 
 	/**
 	 * Called when a specific entry is invalidated from the cache. (See

--- a/src/main/java/net/imglib2/cache/LoaderRemoverCache.java
+++ b/src/main/java/net/imglib2/cache/LoaderRemoverCache.java
@@ -7,21 +7,21 @@ import net.imglib2.cache.util.LoaderRemoverCacheAsLoaderCacheAdapter;
 import net.imglib2.cache.util.LoaderRemoverCacheAsRemoverCacheAdapter;
 import net.imglib2.cache.util.LoaderRemoverCacheKeyAdapter;
 
-public interface LoaderRemoverCache< K, V > extends AbstractCache< K, V >
+public interface LoaderRemoverCache< K, V, D > extends AbstractCache< K, V >
 {
-	V get( K key, CacheLoader< ? super K, ? extends V > loader, CacheRemover< ? super K, ? super V > remover ) throws ExecutionException;
+	V get( K key, CacheLoader< ? super K, ? extends V > loader, CacheRemover< ? super K, V, D > remover ) throws ExecutionException;
 
-	default LoaderCache< K, V > withRemover( final CacheRemover< K, V > remover )
+	default LoaderCache< K, V > withRemover( final CacheRemover< K, V, D > remover )
 	{
 		return new LoaderRemoverCacheAsLoaderCacheAdapter<>( this, remover );
 	}
 
-	default RemoverCache< K, V > withLoader( final CacheLoader< K, V > loader )
+	default RemoverCache< K, V, D > withLoader( final CacheLoader< K, V > loader )
 	{
 		return new LoaderRemoverCacheAsRemoverCacheAdapter<>( this, loader );
 	}
 
-	default < T > LoaderRemoverCache< T, V > mapKeys( final KeyBimap< T, K > keymap )
+	default < T > LoaderRemoverCache< T, V, D > mapKeys( final KeyBimap< T, K > keymap )
 	{
 		return new LoaderRemoverCacheKeyAdapter<>( this, keymap );
 	}

--- a/src/main/java/net/imglib2/cache/RemoverCache.java
+++ b/src/main/java/net/imglib2/cache/RemoverCache.java
@@ -6,16 +6,16 @@ import net.imglib2.cache.util.KeyBimap;
 import net.imglib2.cache.util.RemoverCacheAsCacheAdapter;
 import net.imglib2.cache.util.RemoverCacheKeyAdapter;
 
-public interface RemoverCache< K, V > extends AbstractCache< K, V >
+public interface RemoverCache< K, V, D > extends AbstractCache< K, V >
 {
-	V get( K key, CacheRemover< ? super K, ? super V > remover ) throws ExecutionException;
+	V get( K key, CacheRemover< ? super K, V, D > remover ) throws ExecutionException;
 
-	default Cache< K, V > withRemover( final CacheRemover< K, V > remover )
+	default Cache< K, V > withRemover( final CacheRemover< K, V, D > remover )
 	{
 		return new RemoverCacheAsCacheAdapter<>( this, remover );
 	}
 
-	default < T > RemoverCache< T, V > mapKeys( final KeyBimap< T, K > keymap )
+	default < T > RemoverCache< T, V, D > mapKeys( final KeyBimap< T, K > keymap )
 	{
 		return new RemoverCacheKeyAdapter<>( this, keymap );
 	}

--- a/src/main/java/net/imglib2/cache/img/DirtyDiskCellCache.java
+++ b/src/main/java/net/imglib2/cache/img/DirtyDiskCellCache.java
@@ -30,9 +30,9 @@ public class DirtyDiskCellCache< A extends Dirty > extends DiskCellCache< A >
 	}
 
 	@Override
-	public void onRemoval( final Long key, final Cell< A > value )
+	public void onRemoval( final Long key, final A valueData )
 	{
-		if ( value.getData().isDirty() )
-			super.onRemoval( key, value );
+		if ( valueData.isDirty() )
+			super.onRemoval( key, valueData );
 	}
 }

--- a/src/main/java/net/imglib2/cache/img/DiskCachedCellImgFactory.java
+++ b/src/main/java/net/imglib2/cache/img/DiskCachedCellImgFactory.java
@@ -235,12 +235,12 @@ public class DiskCachedCellImgFactory< T extends NativeType< T > > extends Nativ
 						AccessIo.get( type, options.accessFlags() ),
 						entitiesPerPixel );
 
-		final IoSync< Long, Cell< A > > iosync = new IoSync<>(
+		final IoSync< Long, Cell< A >, A > iosync = new IoSync<>(
 				diskcache,
 				options.numIoThreads(),
 				options.maxIoQueueSize() );
 
-		LoaderRemoverCache< Long, Cell< A > > listenableCache;
+		LoaderRemoverCache< Long, Cell< A >, A > listenableCache;
 		switch ( options.cacheType() )
 		{
 		case BOUNDED:

--- a/src/main/java/net/imglib2/cache/util/Caches.java
+++ b/src/main/java/net/imglib2/cache/util/Caches.java
@@ -20,8 +20,8 @@ public class Caches
 		return new LoaderCacheKeyAdapter<>( cache, keymap );
 	}
 
-	public static < K, L, V > LoaderRemoverCache< K, V >
-			mapKeys( final LoaderRemoverCache< L, V > cache, final KeyBimap< K, L > keymap )
+	public static < K, L, V, D > LoaderRemoverCache< K, V, D >
+			mapKeys( final LoaderRemoverCache< L, V, D > cache, final KeyBimap< K, L > keymap )
 	{
 		return new LoaderRemoverCacheKeyAdapter<>( cache, keymap );
 	}
@@ -32,8 +32,8 @@ public class Caches
 		return new CacheKeyAdapter<>( cache, keymap );
 	}
 
-	public static < K, L, V > RemoverCache< K, V >
-			mapKeys( final RemoverCache< L, V > cache, final KeyBimap< K, L > keymap )
+	public static < K, L, V, D > RemoverCache< K, V, D >
+			mapKeys( final RemoverCache< L, V, D > cache, final KeyBimap< K, L > keymap )
 	{
 		return new RemoverCacheKeyAdapter<>( cache, keymap );
 	}
@@ -50,8 +50,8 @@ public class Caches
 		return new LoaderCacheAsCacheAdapter<>( cache, loader );
 	}
 
-	public static < K, V > LoaderCache< K, V >
-			withRemover( final LoaderRemoverCache< K, V > cache, final CacheRemover< K, V > removalListener )
+	public static < K, V, D > LoaderCache< K, V >
+			withRemover( final LoaderRemoverCache< K, V, D > cache, final CacheRemover< K, V, D > removalListener )
 	{
 		return new LoaderRemoverCacheAsLoaderCacheAdapter<>( cache, removalListener );
 	}

--- a/src/main/java/net/imglib2/cache/util/LoaderRemoverCacheAsLoaderCacheAdapter.java
+++ b/src/main/java/net/imglib2/cache/util/LoaderRemoverCacheAsLoaderCacheAdapter.java
@@ -21,13 +21,13 @@ import net.imglib2.cache.LoaderRemoverCache;
  *
  * @author Tobias Pietzsch
  */
-public class LoaderRemoverCacheAsLoaderCacheAdapter< K, V > implements LoaderCache< K, V >
+public class LoaderRemoverCacheAsLoaderCacheAdapter< K, V, D > implements LoaderCache< K, V >
 {
-	private final LoaderRemoverCache< K, V > cache;
+	private final LoaderRemoverCache< K, V, D > cache;
 
-	private final CacheRemover< K, V > remover;
+	private final CacheRemover< K, V, D > remover;
 
-	public LoaderRemoverCacheAsLoaderCacheAdapter( final LoaderRemoverCache< K, V > cache, final CacheRemover< K, V > remover )
+	public LoaderRemoverCacheAsLoaderCacheAdapter( final LoaderRemoverCache< K, V, D > cache, final CacheRemover< K, V, D > remover )
 	{
 		this.cache = cache;
 		this.remover = remover;

--- a/src/main/java/net/imglib2/cache/util/LoaderRemoverCacheAsRemoverCacheAdapter.java
+++ b/src/main/java/net/imglib2/cache/util/LoaderRemoverCacheAsRemoverCacheAdapter.java
@@ -21,13 +21,13 @@ import net.imglib2.cache.RemoverCache;
  *
  * @author Tobias Pietzsch
  */
-public class LoaderRemoverCacheAsRemoverCacheAdapter< K, V > implements RemoverCache< K, V >
+public class LoaderRemoverCacheAsRemoverCacheAdapter< K, V, D > implements RemoverCache< K, V, D >
 {
-	private final LoaderRemoverCache< K, V > cache;
+	private final LoaderRemoverCache< K, V, D > cache;
 
 	private final CacheLoader< K, V > loader;
 
-	public LoaderRemoverCacheAsRemoverCacheAdapter( final LoaderRemoverCache< K, V > cache, final CacheLoader< K, V > loader )
+	public LoaderRemoverCacheAsRemoverCacheAdapter( final LoaderRemoverCache< K, V, D > cache, final CacheLoader< K, V > loader )
 	{
 		this.cache = cache;
 		this.loader = loader;
@@ -40,7 +40,7 @@ public class LoaderRemoverCacheAsRemoverCacheAdapter< K, V > implements RemoverC
 	}
 
 	@Override
-	public V get( final K key, final CacheRemover< ? super K, ? super V > remover ) throws ExecutionException
+	public V get( final K key, final CacheRemover< ? super K, V, D > remover ) throws ExecutionException
 	{
 		return cache.get( key, loader, remover );
 	}

--- a/src/main/java/net/imglib2/cache/util/LoaderRemoverCacheKeyAdapter.java
+++ b/src/main/java/net/imglib2/cache/util/LoaderRemoverCacheKeyAdapter.java
@@ -6,9 +6,9 @@ import net.imglib2.cache.CacheLoader;
 import net.imglib2.cache.LoaderRemoverCache;
 import net.imglib2.cache.CacheRemover;
 
-public class LoaderRemoverCacheKeyAdapter< K, L, V, C extends LoaderRemoverCache< L, V > >
+public class LoaderRemoverCacheKeyAdapter< K, L, V, D, C extends LoaderRemoverCache< L, V, D > >
 		extends AbstractCacheKeyAdapter< K, L, V, C >
-		implements LoaderRemoverCache< K, V >
+		implements LoaderRemoverCache< K, V, D >
 {
 	public LoaderRemoverCacheKeyAdapter( final C cache, final KeyBimap< K, L > keymap )
 	{
@@ -16,11 +16,36 @@ public class LoaderRemoverCacheKeyAdapter< K, L, V, C extends LoaderRemoverCache
 	}
 
 	@Override
-	public V get( final K key, final CacheLoader< ? super K, ? extends V > loader, final CacheRemover< ? super K, ? super V > remover ) throws ExecutionException
+	public V get( final K key, final CacheLoader< ? super K, ? extends V > loader, final CacheRemover< ? super K, V, D > remover ) throws ExecutionException
 	{
-		return cache.get(
-				keymap.getTarget( key ),
-				l -> loader.get( keymap.getSource( l ) ),
-				( l, v ) -> remover.onRemoval( keymap.getSource( l ), v ) );
+		class LoaderRemover implements CacheRemover< L, V, D >, CacheLoader< L, V >
+		{
+			@Override
+			public void onRemoval( final L key, final D valueData )
+			{
+				remover.onRemoval( keymap.getSource( key ), valueData );
+			}
+
+			@Override
+			public D extract( final V value )
+			{
+				return remover.extract( value );
+			}
+
+			@Override
+			public V reconstruct( final L key, final D valueData )
+			{
+				return remover.reconstruct( keymap.getSource( key ), valueData );
+			}
+
+			@Override
+			public V get( final L key ) throws Exception
+			{
+				return loader.get( keymap.getSource( key ) );
+			}
+		};
+		final LoaderRemover lr = new LoaderRemover();
+
+		return cache.get( keymap.getTarget( key ), lr, lr );
 	}
 }

--- a/src/main/java/net/imglib2/cache/util/RemoverCacheAsCacheAdapter.java
+++ b/src/main/java/net/imglib2/cache/util/RemoverCacheAsCacheAdapter.java
@@ -19,13 +19,13 @@ import net.imglib2.cache.RemoverCache;
  *
  * @author Tobias Pietzsch
  */
-public class RemoverCacheAsCacheAdapter< K, V > implements Cache< K, V >
+public class RemoverCacheAsCacheAdapter< K, V, D > implements Cache< K, V >
 {
-	private final RemoverCache< K, V > cache;
+	private final RemoverCache< K, V, D > cache;
 
-	private final CacheRemover< K, V > remover;
+	private final CacheRemover< K, V, D > remover;
 
-	public RemoverCacheAsCacheAdapter( final RemoverCache< K, V > cache, final CacheRemover< K, V > remover )
+	public RemoverCacheAsCacheAdapter( final RemoverCache< K, V, D > cache, final CacheRemover< K, V, D > remover )
 	{
 		this.cache = cache;
 		this.remover = remover;

--- a/src/main/java/net/imglib2/cache/volatiles/VolatileLoaderRemoverCache.java
+++ b/src/main/java/net/imglib2/cache/volatiles/VolatileLoaderRemoverCache.java
@@ -10,7 +10,7 @@ import net.imglib2.cache.CacheRemover;
  * <p>
  * TODO: REMOVE?
  */
-public interface VolatileLoaderRemoverCache< K, V > extends AbstractVolatileCache< K, V >
+public interface VolatileLoaderRemoverCache< K, V, D > extends AbstractVolatileCache< K, V >
 {
-	V get( K key, VolatileCacheLoader< ? super K, ? extends V > loader, CacheRemover< ? super K, ? super V > remover, CacheHints cacheHints ) throws ExecutionException;
+	V get( K key, VolatileCacheLoader< ? super K, ? extends V > loader, CacheRemover< ? super K, V, D > remover, CacheHints cacheHints ) throws ExecutionException;
 }

--- a/src/main/java/net/imglib2/cache/volatiles/VolatileRemoverCache.java
+++ b/src/main/java/net/imglib2/cache/volatiles/VolatileRemoverCache.java
@@ -10,7 +10,7 @@ import net.imglib2.cache.CacheRemover;
  * <p>
  * TODO: REMOVE?
  */
-public interface VolatileRemoverCache< K, V > extends AbstractVolatileCache< K, V >
+public interface VolatileRemoverCache< K, V, D > extends AbstractVolatileCache< K, V >
 {
-	V get( K key, CacheRemover< ? super K, ? super V > remover, CacheHints cacheHints ) throws ExecutionException;
+	V get( K key, CacheRemover< ? super K, V, D > remover, CacheHints cacheHints ) throws ExecutionException;
 }

--- a/src/test/java/net/imglib2/cache/img/DiskCachedCellImgTest.java
+++ b/src/test/java/net/imglib2/cache/img/DiskCachedCellImgTest.java
@@ -1,0 +1,40 @@
+package net.imglib2.cache.img;
+
+import net.imglib2.Cursor;
+import net.imglib2.img.Img;
+import net.imglib2.position.FunctionRandomAccessible;
+import net.imglib2.type.numeric.real.FloatType;
+import net.imglib2.view.Views;
+import org.junit.Test;
+
+public class DiskCachedCellImgTest
+{
+	/**
+	 * Test whether caching evicted cells to disk (and reading back) works correctly.
+	 */
+	@Test
+	public void testDiskCachedCellImg()
+	{
+		final long[] dims = new long[] { 20_000_000 };
+
+		FunctionRandomAccessible< FloatType > src = new FunctionRandomAccessible<>( 1, ( pos, type ) -> type.set( pos.getFloatPosition( 0 ) ), FloatType::new );
+		final Img< FloatType > dst = new DiskCachedCellImgFactory<>( new FloatType(),
+				DiskCachedCellImgOptions.options()
+						.cacheType( DiskCachedCellImgOptions.CacheType.BOUNDED )
+						.maxCacheSize( 2 )
+						.cellDimensions( 256 ) ).create( dims );
+
+		final Cursor< FloatType > srcCursor = Views.interval( src, dst ).cursor();
+		final Cursor< FloatType > dstCursor = dst.cursor();
+
+		while ( srcCursor.hasNext() )
+			dstCursor.next().set( srcCursor.next() );
+
+		srcCursor.reset();
+		dstCursor.reset();
+
+		while ( srcCursor.hasNext() )
+			if ( dstCursor.next().get() != srcCursor.next().get() )
+				throw new RuntimeException();
+	}
+}


### PR DESCRIPTION
This [test (`DiskCachedCellImgTest`)](https://github.com/imglib/imglib2-cache/blob/e95017537146021dc5f95a4b05831e654a791884/src/test/java/net/imglib2/cache/img/DiskCachedCellImgTest.java) fails with Java 11 in `imglib2-cache 1.0.0-beta-11`.

See [this forum post](https://forum.image.sc/t/conversation-with-the-openjdk-developers-about-javafx-and-unsafe/21901/6) for explanation.

This PR fixes it by adding to the `CacheRemover` interface methods to extract "relevant data" from a cached value `V`, which is basically everything besides the actual `V` object. This data can then be (strongly) referenced to from  the cache and passed to the `CacheRemover` when the `V` is garbage-collected. To make this work, the "relevant data" must be effectively `final` in `V`.