### PR TITLE
Add IoSync.shutdown method

### DIFF
--- a/src/main/java/net/imglib2/cache/IoSync.java
+++ b/src/main/java/net/imglib2/cache/IoSync.java
@@ -64,7 +64,7 @@ public class IoSync< K, V, D > implements CacheLoader< K, V >, CacheRemover< K, 
 	 */
 	final PausableQueue< K > queue;
 
-	private final List<Writer> writers = new ArrayList<>();
+	private final List< Writer > writers = new ArrayList<>();
 
 	/**
 	 * Create a new {@link IoSync} that asynchronously forwards to the specified
@@ -141,6 +141,11 @@ public class IoSync< K, V, D > implements CacheLoader< K, V >, CacheRemover< K, 
 		}
 	}
 
+	/**
+	 * Shutdown all internal {@code Writer} instances to free resources.
+	 * Internal threads will terminate and no data will be written to disk
+	 * after shutdown.
+	 */
 	public void shutdown()
 	{
 		for ( final Writer w : writers )
@@ -329,6 +334,11 @@ public class IoSync< K, V, D > implements CacheLoader< K, V >, CacheRemover< K, 
 			super( name );
 		}
 
+		/**
+		 * Shutdown this {@code Writer}: The {@code Writer} will be interrupted
+		 * so it can terminate and resources can be freed. No data will be written
+		 * to disk after shutdown.
+		 */
 		public void shutdown()
 		{
 			shutdown = true;

--- a/src/main/java/net/imglib2/cache/img/DiskCachedCellImg.java
+++ b/src/main/java/net/imglib2/cache/img/DiskCachedCellImg.java
@@ -1,6 +1,7 @@
 package net.imglib2.cache.img;
 
 import net.imglib2.cache.Cache;
+import net.imglib2.cache.IoSync;
 import net.imglib2.img.ImgFactory;
 import net.imglib2.img.cell.Cell;
 import net.imglib2.img.cell.CellGrid;
@@ -23,15 +24,24 @@ public class DiskCachedCellImg< T extends NativeType< T >, A > extends CachedCel
 {
 	private final DiskCachedCellImgFactory< T > factory;
 
+	private final IoSync iosync;
+
 	public DiskCachedCellImg(
 			final DiskCachedCellImgFactory< T > factory,
 			final CellGrid grid,
 			final Fraction entitiesPerPixel,
 			final Cache< Long, Cell< A > > cache,
+			final IoSync iosync,
 			final A accessType )
 	{
 		super( grid, entitiesPerPixel, cache, accessType );
 		this.factory = factory;
+		this.iosync = iosync;
+	}
+
+	public void shutdown()
+	{
+		iosync.shutdown();
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/cache/img/DiskCachedCellImg.java
+++ b/src/main/java/net/imglib2/cache/img/DiskCachedCellImg.java
@@ -39,6 +39,11 @@ public class DiskCachedCellImg< T extends NativeType< T >, A > extends CachedCel
 		this.iosync = iosync;
 	}
 
+	/**
+	 * Shutdown the internal {@link IoSync} to free resources via
+	 * {@link IoSync#shutdown()}. No data will be written to disk after
+	 * shutdown.
+	 */
 	public void shutdown()
 	{
 		iosync.shutdown();

--- a/src/main/java/net/imglib2/cache/img/DiskCachedCellImgFactory.java
+++ b/src/main/java/net/imglib2/cache/img/DiskCachedCellImgFactory.java
@@ -257,7 +257,13 @@ public class DiskCachedCellImgFactory< T extends NativeType< T > > extends Nativ
 				.withLoader( iosync );
 
 		final A accessType = ArrayDataAccessFactory.get( typeFactory, options.accessFlags() );
-		final DiskCachedCellImg< T, ? extends A > img = new DiskCachedCellImg<>( this, grid, entitiesPerPixel, cache, accessType );
+		final DiskCachedCellImg< T, ? extends A > img = new DiskCachedCellImg<>(
+				this,
+				grid,
+				entitiesPerPixel,
+				cache,
+				iosync,
+				accessType );
 		img.setLinkedType( typeFactory.createLinkedType( img ) );
 		return img;
 	}

--- a/src/test/java/net/imglib2/cache/img/DiskCachedCellImgTest.java
+++ b/src/test/java/net/imglib2/cache/img/DiskCachedCellImgTest.java
@@ -18,7 +18,7 @@ public class DiskCachedCellImgTest
 		final long[] dims = new long[] { 20_000_000 };
 
 		FunctionRandomAccessible< FloatType > src = new FunctionRandomAccessible<>( 1, ( pos, type ) -> type.set( pos.getFloatPosition( 0 ) ), FloatType::new );
-		final Img< FloatType > dst = new DiskCachedCellImgFactory<>( new FloatType(),
+		final DiskCachedCellImg< FloatType, ? > dst = new DiskCachedCellImgFactory<>( new FloatType(),
 				DiskCachedCellImgOptions.options()
 						.cacheType( DiskCachedCellImgOptions.CacheType.BOUNDED )
 						.maxCacheSize( 2 )
@@ -36,5 +36,6 @@ public class DiskCachedCellImgTest
 		while ( srcCursor.hasNext() )
 			if ( dstCursor.next().get() != srcCursor.next().get() )
 				throw new RuntimeException();
+		dst.shutdown();
 	}
 }

--- a/src/test/java/net/imglib2/cache/img/DiskCachedCellImgTest.java
+++ b/src/test/java/net/imglib2/cache/img/DiskCachedCellImgTest.java
@@ -18,7 +18,7 @@ public class DiskCachedCellImgTest
 		final long[] dims = new long[] { 20_000_000 };
 
 		FunctionRandomAccessible< FloatType > src = new FunctionRandomAccessible<>( 1, ( pos, type ) -> type.set( pos.getFloatPosition( 0 ) ), FloatType::new );
-		final DiskCachedCellImg< FloatType, ? > dst = new DiskCachedCellImgFactory<>( new FloatType(),
+		final Img< FloatType > dst = new DiskCachedCellImgFactory<>( new FloatType(),
 				DiskCachedCellImgOptions.options()
 						.cacheType( DiskCachedCellImgOptions.CacheType.BOUNDED )
 						.maxCacheSize( 2 )
@@ -36,6 +36,5 @@ public class DiskCachedCellImgTest
 		while ( srcCursor.hasNext() )
 			if ( dstCursor.next().get() != srcCursor.next().get() )
 				throw new RuntimeException();
-		dst.shutdown();
 	}
 }


### PR DESCRIPTION
Also add IoSync as member to DiskCachedCellImg so it can be shutdown as well.

Fixes #12

Fun fact: I was unable to create a `Writer[]` array (Generic array creation error) and was very confused by it. Now I understand that it is because it's an inner class of `IoSync`, which is generic and thus, Writer is generic, as well.

I tested with this small method:
```java
final DiskCachedCellImgFactory<UnsignedByteType> fac = new DiskCachedCellImgFactory<>(new UnsignedByteType());
DiskCachedCellImg<UnsignedByteType, ?> img = fac.create(10, 20, 30);

final boolean shutdownAfterUse = true;

while (true) {
    Thread.sleep(2000);
    if (shutdownAfterUse)
        img.shutdown();
    img = fac.create(10, 20, 30);
}
```

visual vm screenshots

 - `shutdownAfterUse = false`
 1. monitor
![iosync-no-shutdown-monitor](https://user-images.githubusercontent.com/1086317/63587486-23dadb80-c572-11e9-8d0e-546cf3ca4e03.png) 
 2. all threads
![iosync-no-shutdown-all-threads](https://user-images.githubusercontent.com/1086317/63587492-276e6280-c572-11e9-93ba-78a43d3e1759.png)
 3. live threads
![iosync-no-shutdown-live-threads](https://user-images.githubusercontent.com/1086317/63587495-2a695300-c572-11e9-9c4a-f1738e141fbd.png)

 - `shutdownAfterUse = true`
 1. monitor
![iosync-with-shutdown-monitor](https://user-images.githubusercontent.com/1086317/63587545-4a991200-c572-11e9-8deb-239f23344d56.png)
 2. all threads
![iosync-with-shutdown-all-threads](https://user-images.githubusercontent.com/1086317/63587553-4f5dc600-c572-11e9-869f-4d43fb715f8c.png)
 3. live threads
![iosync-with-shutdown-live-threads](https://user-images.githubusercontent.com/1086317/63587563-54bb1080-c572-11e9-9147-eefab35c629f.png)


 - without shutdown: 
   - total number of live threads grows linearly
   - all threads == live threads
   - iosync threads stay alive forever

 - with shutdown:
   - total number of live threads is constant
   - all threads != live threads, in particular live iosync threads == 1
   - iosync threads are short-lived

This adds the `IoSync` as a member to the `DiskCachedCellImg` and breaks the interface of the constructor.
