### PR TITLE
Remove obsolete properties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,9 +110,6 @@ Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
 Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
 Jean-Yves Tinevez and Michael Zinsmaier.</license.copyrightOwners>
 
-		<enforcer.skip>true</enforcer.skip>
-		<imglib2.version>5.9.3</imglib2.version>
-
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>deploy-to-scijava</releaseProfiles>
 	</properties>


### PR DESCRIPTION
I was able to build and test locally after removing those lines. I am not sure if there are any other implications when using in a wider context like Fiji. `imglib2.version` is defined as `5.11.1` in parent pom.